### PR TITLE
machine-as-action: should automatically infer responseType: 'view' when a `viewTemplatePath` is defined.

### DIFF
--- a/helpers/normalize-responses.js
+++ b/helpers/normalize-responses.js
@@ -93,10 +93,14 @@ module.exports = function normalizeResponses (configuredResponses, exits){
     // ==============================================================================================================
 
 
-    // If `responseType` is not set, we assume it must be "" (empty string / standard)
-    // unless this is the error exit, in which case we assume it must be `error`.
+    // If `responseType` is not set, we assume it must be "" (empty string / standard), UNLESS:
+    // • if a `viewTemplatePath` was provided, in which case we assume it must be `view`
+    // • or otherwise if this is the error exit, in which case we assume it must be `error`
     if (_.isUndefined(exitDef.responseType)) {
-      if (exitCodeName === 'error') {
+      if (exitDef.viewTemplatePath) {
+        exitDef.responseType = 'view';
+      }
+      else if (exitCodeName === 'error') {
         exitDef.responseType = 'error';
       }
       else {

--- a/helpers/normalize-responses.js
+++ b/helpers/normalize-responses.js
@@ -154,6 +154,12 @@ module.exports = function normalizeResponses (configuredResponses, exits){
       if (_.isUndefined(outputExample)) {
         outputExample = '/some/other/place';
         exitDef.outputExample = outputExample;
+        // Currently, we have to set BOTH `outputExample` and `example`.
+        // This will be normalized soon in a patch release of the machine runner, and at that
+        // point, this line can be removed:
+        // ------------------------------------------------
+        exitDef.example = outputExample;
+        // ------------------------------------------------
       }
 
     }

--- a/helpers/normalize-responses.js
+++ b/helpers/normalize-responses.js
@@ -146,6 +146,16 @@ module.exports = function normalizeResponses (configuredResponses, exits){
       if (!_.isUndefined(outputExample) && !_.isString(outputExample)) {
         throw new Error(util.format('`machine-as-action` cannot configure exit "%s" to redirect.  The redirect URL is based on the return value from the exit, so the exit\'s `example` must be a string.  But instead, it\'s: ', exitCodeName,util.inspect(outputExample, false, null)));
       }
+
+      // If no outputExample was specified, modify the exit in-memory to make it a string.
+      // This is criticial, otherwise the machine runner will convert the runtime output into an Error instance,
+      // since it'll think the exit isn't expecting any output (note that we also set the `outputExample` local
+      // variable, just for consistency.)
+      if (_.isUndefined(outputExample)) {
+        outputExample = '/some/other/place';
+        exitDef.outputExample = outputExample;
+      }
+
     }
     else if (exitDef.responseType === 'view') {
       // Note that we tolerate `===` so that it can be used for performance reasons.

--- a/helpers/normalize-responses.js
+++ b/helpers/normalize-responses.js
@@ -33,6 +33,8 @@ module.exports = function normalizeResponses (configuredResponses, exits){
     }
   }, exits);
 
+
+  // Return normalized exit definitions.
   return _.reduce(exits, function (memo, exitDef, exitCodeName) {
 
     // If a response def exists, merge its properties into the exit definition.
@@ -56,35 +58,42 @@ module.exports = function normalizeResponses (configuredResponses, exits){
 
     // If response metadata was explicitly defined, use it.
     // (also validate each property on the way in to ensure it is valid)
-    //
+    // ================================================================================================
+
     // Response type (`responseType`)
     if (!_.isUndefined(exitDef.responseType)) {
       if (!_.contains(['', 'error', 'status', 'json', 'redirect', 'view'], exitDef.responseType)) {
         throw new Error(util.format('`machine-as-action` doesn\'t know how to handle the response type ("%s") specified for exit "%s".', exitDef.responseType, exitCodeName));
       }
-    }
+    }//>-•
+
     // Status code (`statusCode`)
     if (!_.isUndefined(exitDef.statusCode)) {
+
+      // Ensure it's a number.
       exitDef.statusCode = +exitDef.statusCode;
-      if (_.isNaN(exitDef.statusCode) || exitDef.statusCode < 100 || exitDef.statusCode > 599) {
-        throw new Error(util.format('`machine-as-action` doesn\'t know how to handle the status code ("%s") specified for exit "%s".  To have MaA use the default status code, omit the `statusCode` property.', exitDef.statusCode, exitCodeName));
+      if (!_.isNumber(exitDef.statusCode) || _.isNaN(exitDef.statusCode) || exitDef.statusCode < 100 || exitDef.statusCode > 599) {
+        throw new Error(util.format('`machine-as-action` doesn\'t know how to handle the status code ("%s") specified for exit "%s".  To have this exit infer an appropriate default status code, just omit the `statusCode` property.', exitDef.statusCode, exitCodeName));
       }
-    }
+
+    }//>-•
+
     // View path (`viewTemplatePath`)
     if (!_.isUndefined(exitDef.viewTemplatePath)) {
-      if (!_.isString(exitDef.viewTemplatePath)) {
-        throw new Error(util.format('`machine-as-action` doesn\'t know how to handle the view path ("%s") specified for exit "%s".', exitDef.viewTemplatePath, exitCodeName));
+      if (exitDef.viewTemplatePath === '' || !_.isString(exitDef.viewTemplatePath)) {
+        throw new Error(util.format('`machine-as-action` doesn\'t know how to handle the view template path ("'+exitDef.viewTemplatePath+'") specified as the `viewTemplatePath` for exit "'+exitCodeName+'".  This should be the relative path to a view file from the `views/` directory, minus the extension (`.ejs`).'));
       }
-    }
+    }//>-•
 
 
 
     // Then set any remaining unspecified stuff to reasonable defaults.
-    // (note that this makes decisions about how to respond based on the
+    // (note that the code below makes decisions about how to respond based on the
     //  static exit definition, not the runtime output value.)
+    // ==============================================================================================================
 
 
-    // If `responseType` is not set, we assume it must be `` (standard)
+    // If `responseType` is not set, we assume it must be "" (empty string / standard)
     // unless this is the error exit, in which case we assume it must be `error`.
     if (_.isUndefined(exitDef.responseType)) {
       if (exitCodeName === 'error') {
@@ -95,6 +104,9 @@ module.exports = function normalizeResponses (configuredResponses, exits){
       }
     }
 
+
+    // Infer appropriate status code:
+    //
     // If status code was not explicitly specified, infer an appropriate code based on the response type and/or exitCodeName.
     if (!exitDef.statusCode) {
       // First, if this is the error exit or this response is using the "error" response type:
@@ -123,20 +135,22 @@ module.exports = function normalizeResponses (configuredResponses, exits){
       else {
         exitDef.statusCode = 500;
       }
-    }
+    }//>-
 
     // Look up the output example for this exit.
     var outputExample = getOutputExample({ exitDef: exitDef });
 
     // Ensure response type is compatible with exit definition
     if (exitDef.responseType === 'redirect') {
+      // Note that we tolerate the absense of an outputExample, since a redirect is assumed to always be a string.
       if (!_.isUndefined(outputExample) && !_.isString(outputExample)) {
         throw new Error(util.format('`machine-as-action` cannot configure exit "%s" to redirect.  The redirect URL is based on the return value from the exit, so the exit\'s `example` must be a string.  But instead, it\'s: ', exitCodeName,util.inspect(outputExample, false, null)));
       }
     }
     else if (exitDef.responseType === 'view') {
+      // Note that we tolerate `===` so that it can be used for performance reasons.
+      // If no output example is provided, we treat it like `===`.
       if (!_.isUndefined(outputExample) && outputExample !== '===' && !_.isPlainObject(outputExample)) {
-        // (Note that we tolerate `===` so that it can be used for performance reasons.)
         throw new Error(util.format('`machine-as-action` cannot configure exit "%s" to show a view.  The return value from the exit is used as view locals (variables accessible inside the view HTML), so the exit\'s `example` must be some sort of dictionary (`{}`).  But instead, it\'s: ', exitCodeName, util.inspect(outputExample, false, null)));
       }
     }
@@ -145,12 +159,12 @@ module.exports = function normalizeResponses (configuredResponses, exits){
       if (!_.isUndefined(outputExample) && _.isUndefined(outputExample)) {
         throw new Error(util.format('`machine-as-action` cannot configure exit "%s" to respond with JSON.  The return value from the exit will be encoded as JSON, so something must be returned...but the exit\'s `example` is undefined.', exitCodeName));
       }
-    }
+    }//>-•
 
     // Log warning if unnecessary stuff is provided (i.e. a `view` was provided along with responseType !== "view")
     if (exitDef.viewTemplatePath && exitDef.responseType !== 'view') {
-      console.error('Warning: unnecessary `view` response metadata provided for an exit which is not configured to respond with a view (actual responseType => "%s").', exitDef.responseType);
-    }
+      console.error('Warning: unnecessary `viewTemplatePath` (response metadata) provided for an exit which is not configured to respond with a view (actual responseType => "'+exitDef.responseType+'").  To resolve, set `responseType: \'view\'`.');
+    }//>-
 
     memo[exitCodeName] = exitDef;
     return memo;

--- a/index.js
+++ b/index.js
@@ -29,30 +29,10 @@ var getOutputExample = require('./helpers/get-output-example');
  * ------------------------------------------------------------------------------------------------
  * @param  {Dictionary} optsOrMachineDef
  *           @required {Dictionary} machine
- *                       A machine definition.
+ *                       A machine definition, with action-specific extensions (e.g. `statusCode` in exits)
  *                       Note that the top-level properties of the machine definition may alternatively
  *                       just be included inline amongst the other machine-as-action specific options.
  *                       * * This inline inclusion is the **RECOMMENDED APPROACH** (see README.md). * *
- *
- *           @optional {Dictionary} responses
- *                       A set of static/lift-time response customizations.
- *                       Each key refers to a particular machine exit, and each
- *                       value is a dictionary of settings.
- *                       @default {}
- *
- *                       e.g.
- *                       {
- *                         success: {
- *                           responseType: 'view',       // ("view"|"redirect"|"")
- *                           viewTemplatePath: 'pages/homepage', // (only relevant if `responseType` is "view")
- *                           statusCode: 204             // any valid HTTP status code
- *                         }
- *                       }
- *
- *                       Note that these additional exit-specific response customizations may alternatively
- *                       be included inline in the exits of the machine definition (purely for convenience).
- *                       * * This inline inclusion is the **RECOMMENDED APPROACH** (see README.md). * *
- *
  *
  *           @optional {Array} files
  *                     An array of input code names identifying inputs which expect to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-as-action",
-  "version": "7.0.8",
+  "version": "7.0.9",
   "description": "Run a machine from an HTTP or WebSocket request.",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha -t 8000"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-as-action",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "Run a machine from an HTTP or WebSocket request.",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha -t 8000"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-as-action",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "description": "Run a machine from an HTTP or WebSocket request.",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha -t 8000"


### PR DESCRIPTION
> #### WARNING:
>
> First, merge https://github.com/treelinehq/machine-as-action/pull/4 before merging this one