### PR TITLE
Treat `null` and `undefined` equally when processing output from an exit with a `view` response.

### DIFF
--- a/index.js
+++ b/index.js
@@ -863,7 +863,7 @@ module.exports = function machineAsAction(optsOrMachineDef) {
                 // Set status code.
                 res = res.status(responses[exitCodeName].statusCode);
 
-                if (_.isUndefined(output)) {
+                if (_.isUndefined(output) || _.isNull(output)) {
                   return res.view(responses[exitCodeName].viewTemplatePath);
                 }
                 else if (_.isObject(output) && !_.isArray(output) && !_.isFunction(output)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-as-action",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Run a machine from an HTTP or WebSocket request.",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha -t 8000"


### PR DESCRIPTION


Since the machine runner will coerce `undefined` to `null` for ref exits, it's unclear whether `output` would _ever_ be undefined, but I don't see any harm in just allowing `null` to be treated the same way as `undefined` (i.e., no view locals).